### PR TITLE
Update to poper2

### DIFF
--- a/lib/pronto/poper.rb
+++ b/lib/pronto/poper.rb
@@ -1,12 +1,12 @@
 require 'pronto'
-require 'poper'
+require 'poper2'
 
 module Pronto
-  class Poper < Runner
+  class Poper2 < Runner
     def run
       return [] unless @patches
 
-      poper_runner = ::Poper::Runner.new(@commit, repo_path.to_s)
+      poper_runner = ::Poper2::Runner.new(@commit, repo_path.to_s)
 
       poper_runner.run
         .select { |error| error.commit != @commit }

--- a/pronto-poper.gemspec
+++ b/pronto-poper.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |s|
   s.require_paths = ['lib']
 
   s.add_dependency('pronto', '~> 0.11.0')
-  s.add_dependency('poper', '~> 0.2.0')
+  s.add_dependency('poper2', '~> 0.3.3')
   s.add_development_dependency('rake', '~> 12.0')
   s.add_development_dependency('rspec', '~> 3.4')
   s.add_development_dependency('rspec-its', '~> 1.2')


### PR DESCRIPTION
This PR updates the poper gem to the new poper2 gem, which allows the use of pronto-poper with the latest versions of rugged.